### PR TITLE
Ignore errors from chmod because it errors on recently deleted files …

### DIFF
--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -28,7 +28,9 @@ module Microbus
         cmd,
         # chown entire working dir, so that build
         # can be accessed as unprivileged user on Linux.
-        "chown -R duser:dgroup #{@work_dir}"
+        # We ignore errors here because errors can occur with files recently
+        # deleted.
+        "(chown -R duser:dgroup #{@work_dir} || true)"
       ]
       docker(cmds.join(' && '))
     end


### PR DESCRIPTION
…with no way to suppress it.

For example:

```
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/sequel-5f142093e985/.bundlecache': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/sequel-5f142093e985/.gitignore': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/sequel-5f142093e985/.travis.gemfile': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/sequel-5f142093e985/.travis.yml': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/sequel-5f142093e985/spec/rcov.opts': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/sequel-5f142093e985/spec/spec_config.rb.example': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/systemd-daemon-44623468b56d/.bundlecache': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/aws-flow-ruby-3790398a7457/.bundlecache': No such file or directory
chown: cannot access '/opt/acquia/cloud-database-api/vendor/cache/cloud-data-api-client-ruby-25db830bf2a3': No such file or directory
chown: cannot access '/opt/acquia/cloud-database-api/vendor/cache/cucumber-ruby-e4daaeb3d256': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.bundlecache': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.gitignore': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.rspec': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.rubocop.yml': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.rubocop_todo.yml': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.travis.yml': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/grape-c54537704f43/.yardopts': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/http-hmac-ruby-8b08d862faec/.bundlecache': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/http-hmac-ruby-8b08d862faec/.gitignore': No such file or directory
chown: changing ownership of '/opt/acquia/cloud-database-api/vendor/cache/http-hmac-ruby-8b08d862faec/.travis.yml': No such file or directory
chown: cannot access '/opt/acquia/cloud-database-api/vendor/cache/microbus-0315061165fc': No such file or directory
chown: cannot access '/opt/acquia/cloud-database-api/vendor/cache/puppet-e7aeb7157673': No such file or directory
rake aborted!
Command failed with status (1): [docker run --interactive=false --rm --volu...]
```
