### PR TITLE
CL-32773 | Replace checksum with sha256

### DIFF
--- a/features/build.feature
+++ b/features/build.feature
@@ -24,5 +24,5 @@ Feature: build
 
   Scenario: Build a basic app with checksum
     When I successfully run `rake build_checksum`
-    Then a file named "build.md5" should exist
-    And the file "build.md5" should contain the MD5 digest for "build.tar.gz"
+    Then a file named "build.sha256" should exist
+    And the file "build.sha256" should contain the SHA-256 digest for "build.tar.gz"

--- a/features/step_definitions/build_steps.rb
+++ b/features/step_definitions/build_steps.rb
@@ -1,6 +1,6 @@
 # rubocop:disable LineLength
-Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?contain the MD5 digest for "([^"]*)"/) do |digest_file, negated, file|
-  digest = Digest::MD5.file(expand_path(file)).hexdigest
+Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?contain the SHA-256 digest for "([^"]*)"/) do |digest_file, negated, file|
+  digest = Digest::SHA256.file(expand_path(file)).hexdigest
   if negated
     expect(digest_file).not_to \
       have_file_content file_content_including(digest)

--- a/lib/microbus/packager.rb
+++ b/lib/microbus/packager.rb
@@ -56,12 +56,12 @@ module Microbus
     private
 
     def checksum
-      Digest::MD5.file(@filename).hexdigest
+      Digest::SHA256.file(@filename).hexdigest
     end
 
     # Generates a checksum of the build file and writes it to a new file.
     #
-    # @return [String] MD5 checksum.
+    # @return [String] SHA256 checksum.
     def write_checksum
       File.write(checksum_file, checksum)
       puts "Created #{checksum_file}"
@@ -76,7 +76,7 @@ module Microbus
       @checksum_file ||= begin
         ext = opts.type == :tar ? '.tar.gz' : File.extname(@filename)
         basename = File.basename(@filename, ext)
-        "#{basename}.md5"
+        "#{basename}.sha256"
       end
     end
 


### PR DESCRIPTION
When generating a checksum on the build, use SHA256 instead of MD5 because
MD5 isn't FIPS compliant.