### PR TITLE
Set target os to linux if building rpm.

### DIFF
--- a/lib/microbus/packager.rb
+++ b/lib/microbus/packager.rb
@@ -44,6 +44,7 @@ module Microbus
       ]
       fpm_opts << "--prefix=#{@prefix}" if @prefix
       fpm_opts << "--package=#{@filename}" if @filename
+      fpm_opts << '--rpm-os=linux' if @opts.type == :rpm
       fpm_opts.concat(opts.fpm_options)
 
       file = fpm('.', fpm_opts)


### PR DESCRIPTION
It is required to set target operation system to linux when building
rpm. Without this option being set, packages packaged on mac will
raise "intended for a different operating system" error.