### PR TITLE
Copy directories in rake task files list

### DIFF
--- a/lib/microbus/rake_task.rb
+++ b/lib/microbus/rake_task.rb
@@ -84,7 +84,7 @@ module Microbus
 
         # Copy only files declared in gemspec.
         files = opts.files.map { |file| Shellwords.escape(file) }
-        sh("rsync -R #{files.join(' ')} #{opts.build_path}")
+        sh("rsync -rR #{files.join(' ')} #{opts.build_path}")
         FileUtils.cp("#{__dir__}/minimize.rb", opts.build_path) if opts.minimize
 
         docker = Docker.new(


### PR DESCRIPTION
The rsync command used to copy project files to the build dir in `Microbus::RakeTask` does not respect directories without the recursive flag. An error message is printed, but it happens early in the build process and does not cause the task to error, so it is easily missed, which is frustrating.