### PR TITLE
PC-15272-branch1 | Pass docker_args for build_docker_image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,6 @@
 
 source 'https://rubygems.org'
 
+gem 'bundler', '2.1.4'
 # Specify your gem's dependencies in microbus.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@
 
 source 'https://rubygems.org'
 
-gem 'bundler', '2.1.4'
 # Specify your gem's dependencies in microbus.gemspec
 gemspec

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -73,8 +73,8 @@ module Microbus
     def build_docker_image(path, tag, fpm_options)
       # Use docker to install, building native extensions on an OS similar to
       # our deployment environment.
-      pass = fpm_options.select{ |s| s.include? 'PASS' }
-      ruby_version = fpm_options.select{ |s| s.include? 'RUBY_VERSION' }
+      pass = fpm_options.detect{ |s| s.include? 'PASS' }
+      ruby_version = fpm_options.detect{ |s| s.include? 'RUBY_VERSION' }
       sh("docker build #{pass} #{ruby_version} -t #{tag} #{path}/.")
     end
 

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -75,7 +75,7 @@ module Microbus
       # our deployment environment.
       pass = fpm_options.select{ |s| s.include? 'PASS' }
       ruby_version = fpm_options.select{ |s| s.include? 'RUBY_VERSION' }
-      sh("docker build --build-arg PASS=#{pass} --build-arg RUBY_VERSION=#{ruby_version} -t #{tag} #{path}/.")
+      sh("docker build #{pass} #{ruby_version} -t #{tag} #{path}/.")
     end
 
     def check_docker

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -74,7 +74,6 @@ module Microbus
       # our deployment environment.
       pass = options[:pass] || ''
       ruby_version = options[:ruby_version] || '3.1.2'
-      sh("docker build -t #{tag} #{os} #{ruby_version} #{path}/.")
       sh("docker build --build-arg PASS=#{pass} --build-arg RUBY_VERSION=#{ruby_version} -t #{tag} #{path}/.")
     end
 

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -73,6 +73,7 @@ module Microbus
     def build_docker_image(path, tag, docker_args)
       # Use docker to install, building native extensions on an OS similar to
       # our deployment environment.
+      docker_args = docker_args.join(' ')
       sh("docker build #{docker_args} -t #{tag} #{path}/.")
     end
 

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -23,7 +23,7 @@ module Microbus
     def prepare
       check_docker
       restore_docker_cache if @cache_dir
-      build_docker_image(@path, @tag, @fpm_options)
+      build_docker_image(@path, @tag, @docker_args)
     end
 
     def run(cmd)

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -22,7 +22,7 @@ module Microbus
     def prepare
       check_docker
       restore_docker_cache if @cache_dir
-      build_docker_image(@path, @tag)
+      build_docker_image(@path, @tag, @options = {})
     end
 
     def run(cmd)
@@ -69,10 +69,13 @@ module Microbus
 
     private
 
-    def build_docker_image(path, tag)
+    def build_docker_image(path, tag, options = {})
       # Use docker to install, building native extensions on an OS similar to
       # our deployment environment.
-      sh("docker build -t #{tag} #{path}/.")
+      self.pass = options[:pass] || ''
+      self.ruby_version = options[:ruby_version] || '2.7'
+      sh("docker build -t #{tag} #{os} #{ruby_version} #{path}/.")
+      sh("docker build --build-arg PASS=#{pass} --build-arg RUBY_VERSION=#{ruby_version} -t #{tag} #{path}/.")
     end
 
     def check_docker

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -72,8 +72,8 @@ module Microbus
     def build_docker_image(path, tag, options = {})
       # Use docker to install, building native extensions on an OS similar to
       # our deployment environment.
-      self.pass = options[:pass] || ''
-      self.ruby_version = options[:ruby_version] || '2.7'
+      pass = options[:pass] || ''
+      ruby_version = options[:ruby_version] || '3.1.2'
       sh("docker build -t #{tag} #{os} #{ruby_version} #{path}/.")
       sh("docker build --build-arg PASS=#{pass} --build-arg RUBY_VERSION=#{ruby_version} -t #{tag} #{path}/.")
     end

--- a/lib/microbus/docker.rb
+++ b/lib/microbus/docker.rb
@@ -7,7 +7,7 @@ module Microbus
 
     # rubocop:disable Metrics/ParameterLists
     def initialize(path:, tag:, work_dir:, local_dir:, cache_dir: nil,
-                   gid: Process::Sys.getegid, uid: Process::Sys.geteuid, fpm_options:)
+                   gid: Process::Sys.getegid, uid: Process::Sys.geteuid, docker_args:)
       @path = path
       @tag = tag
       @work_dir = work_dir
@@ -16,7 +16,7 @@ module Microbus
       @gid = gid
       @uid = uid
       @cache_dir = cache_dir
-      @fpm_options = fpm_options
+      @docker_args = docker_args
     end
     # rubocop:enable Metrics/ParameterLists
 
@@ -70,12 +70,10 @@ module Microbus
 
     private
 
-    def build_docker_image(path, tag, fpm_options)
+    def build_docker_image(path, tag, docker_args)
       # Use docker to install, building native extensions on an OS similar to
       # our deployment environment.
-      pass = fpm_options.detect{ |s| s.include? 'PASS' }
-      ruby_version = fpm_options.detect{ |s| s.include? 'RUBY_VERSION' }
-      sh("docker build #{pass} #{ruby_version} -t #{tag} #{path}/.")
+      sh("docker build #{docker_args} -t #{tag} #{path}/.")
     end
 
     def check_docker

--- a/lib/microbus/rake_task.rb
+++ b/lib/microbus/rake_task.rb
@@ -10,11 +10,11 @@ require_relative 'packager'
 module Microbus
   # Provides a custom rake task.
   class RakeTask < Rake::TaskLib # rubocop:disable Metrics/ClassLength
-    Options = Struct.new(:arch, :build_path, :checksum, :deployment_path,
+    Options = Struct.new(:arch, :build_path, :checksum, :deployment_path, :docker_args,
                          :docker_path, :docker_cache, :docker_image, :filename,
                          :files, :fpm_options, :gem_helper, :minimize, :name,
                          :smoke_test_cmd, :type, :version, :binstub_shebang,
-                         :gid, :uid, :docker_args) do
+                         :gid, :uid) do
       class << self
         private :new
         # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -25,6 +25,7 @@ module Microbus
           o.version = gem_helper.gemspec.version
           o.build_path = "#{gem_helper.base}/build"
           o.deployment_path = "/opt/#{o.name}"
+          o.docker_args = []
           o.docker_path = "#{gem_helper.base}/docker"
           o.docker_image = "local/#{o.name}-builder"
           o.filename = ENV['OUTPUT_FILE']
@@ -38,7 +39,6 @@ module Microbus
           o.binstub_shebang = nil
           o.gid = Process::Sys.getegid
           o.uid = Process::Sys.geteuid
-          o.docker_args = nil
           # Set user overrides.
           block&.call(o) if block
           o.freeze

--- a/lib/microbus/rake_task.rb
+++ b/lib/microbus/rake_task.rb
@@ -78,7 +78,7 @@ module Microbus
           cache_dir: opts.docker_cache,
           gid: opts.gid,
           uid: opts.uid,
-          fpm_options: fpm_options
+          fpm_options: opts.fpm_options
         )
         docker.prepare
         puts "Detected Architecture: #{docker.architecture(opts.type)}"
@@ -104,7 +104,7 @@ module Microbus
           cache_dir: opts.docker_cache,
           gid: opts.gid,
           uid: opts.uid,
-          fpm_options: fpm_options
+          fpm_options: opts.fpm_options
         )
 
         docker.prepare

--- a/lib/microbus/rake_task.rb
+++ b/lib/microbus/rake_task.rb
@@ -14,7 +14,7 @@ module Microbus
                          :docker_path, :docker_cache, :docker_image, :filename,
                          :files, :fpm_options, :gem_helper, :minimize, :name,
                          :smoke_test_cmd, :type, :version, :binstub_shebang,
-                         :gid, :uid) do
+                         :gid, :uid, :docker_args) do
       class << self
         private :new
         # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -38,6 +38,7 @@ module Microbus
           o.binstub_shebang = nil
           o.gid = Process::Sys.getegid
           o.uid = Process::Sys.geteuid
+          o.docker_args = nil
           # Set user overrides.
           block&.call(o) if block
           o.freeze
@@ -78,7 +79,7 @@ module Microbus
           cache_dir: opts.docker_cache,
           gid: opts.gid,
           uid: opts.uid,
-          fpm_options: opts.fpm_options
+          docker_args: opts.docker_args
         )
         docker.prepare
         puts "Detected Architecture: #{docker.architecture(opts.type)}"
@@ -104,7 +105,7 @@ module Microbus
           cache_dir: opts.docker_cache,
           gid: opts.gid,
           uid: opts.uid,
-          fpm_options: opts.fpm_options
+          docker_args: opts.docker_args
         )
 
         docker.prepare

--- a/lib/microbus/rake_task.rb
+++ b/lib/microbus/rake_task.rb
@@ -77,7 +77,8 @@ module Microbus
           local_dir: opts.build_path,
           cache_dir: opts.docker_cache,
           gid: opts.gid,
-          uid: opts.uid
+          uid: opts.uid,
+          fpm_options: fpm_options
         )
         docker.prepare
         puts "Detected Architecture: #{docker.architecture(opts.type)}"
@@ -102,7 +103,8 @@ module Microbus
           local_dir: opts.build_path,
           cache_dir: opts.docker_cache,
           gid: opts.gid,
-          uid: opts.uid
+          uid: opts.uid,
+          fpm_options: fpm_options
         )
 
         docker.prepare


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
```
  opts.docker_args = %w[
    --build-arg RUBY_VERSION=3.1.2
  ]
  opts.docker_args << '--build-arg PASS=123'
```
```
[cloudservicesdev|hosting-dev:pc-team-23] ~/Documents/OfficeWorks/Projects/AcquiaProjects/e_fields/ah-base-server$ rake fields-deb --trace
.....................................
docker build --build-arg RUBY_VERSION=3.1.2 --build-arg PASS=123 -t local/ah-base-server-builder /Users/erandidissanayaka/Documents/OfficeWorks/Projects/AcquiaProjects/e_fields/ah-base-server/xenial/docker/fields/.
[+] Building 1.2s (13/13) FINISHED                                                                                                                                                                                                            
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 37B   
```