### PR TITLE
PC-17326 | Update rubocop TargetRubyVersion to 3.1 in microbus

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1.2
   Exclude:
   - '**/*/binstubs/**/*'
   - '**/*/build/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1.2
+  TargetRubyVersion: 3.1
   Exclude:
   - '**/*/binstubs/**/*'
   - '**/*/build/**/*'

--- a/features/fixtures/basic-app/basic.gemspec
+++ b/features/fixtures/basic-app/basic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
                        '*.ru', '*.yml',
                        '{bin,config,db,doc,lib,schema,script}/**/*']
   s.require_path = 'lib'
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 3.1.2'
   s.bindir = 'bin'
   s.executables = Dir['bin/*'].map { |f| File.basename(f) }
 

--- a/features/fixtures/basic-app/basic.gemspec
+++ b/features/fixtures/basic-app/basic.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
                        '*.ru', '*.yml',
                        '{bin,config,db,doc,lib,schema,script}/**/*']
   s.require_path = 'lib'
-  s.required_ruby_version = '>= 3.1.2'
+  s.required_ruby_version = '>= 2.6' # rubocop:disable Gemspec/RequiredRubyVersion
   s.bindir = 'bin'
   s.executables = Dir['bin/*'].map { |f| File.basename(f) }
 

--- a/microbus.gemspec
+++ b/microbus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 3.1.2'
 
   s.add_dependency 'bundler'
   s.add_dependency 'fpm', '> 1.4'

--- a/microbus.gemspec
+++ b/microbus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 3.1.2'
+  s.required_ruby_version = '>= 2.6' # rubocop:disable Gemspec/RequiredRubyVersion
 
   s.add_dependency 'bundler'
   s.add_dependency 'fpm', '> 1.4'


### PR DESCRIPTION
## Testing steps

`ah-web-server` PR: https://github.com/acquia/ah-web-server/pull/559 (which includes https://github.com/acquia/ah-web-server/pull/557)

New Tag version of `ah-web-server` package: https://github.com/acquia/ah-web-server/releases/tag/2.7.27-PC17326-1-manual-tag-3

1. Created a web server
```
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ bundle exec ah-server allocate web -r us-east-1 -z us-east-1f -t t2.medium --fs-cluster-id 121 --hosting_version devel_master_2168fc1
WARNING: Nokogiri was built against libxml version 2.11.5, but has dynamically loaded 2.9.4
Please enter your MFA: 733047
web-472
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ 
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ bundle exec ah-server launch web-472
WARNING: Nokogiri was built against libxml version 2.11.5, but has dynamically loaded 2.9.4
[2023-10-17 14:07:25] Waiting for: new instance to have launched.
[2023-10-17 14:07:38] Waiting for: {:status=>[:running]}
[2023-10-17 14:08:24] Adding tags to launched instance i-099681ee5c6973e0c: [<Aq::Hosting::Type::AWSTag key:"ah_server_name", value:"web-472">, <Aq::Hosting::Type::AWSTag key:"ah_stage", value:"ama-test">, <Aq::Hosting::Type::AWSTag key:"ah_launching_user", value:"ahlauncher">, <Aq::Hosting::Type::AWSTag key:"acquia:bu", value:"dc">, <Aq::Hosting::Type::AWSTag key:"acquia:expiry", value:"9999-01-01">, <Aq::Hosting::Type::AWSTag key:"acquia:stage", value:"ama-test">, <Aq::Hosting::Type::AWSTag key:"acquia:consumer", value:"ama-test">, <Aq::Hosting::Type::AWSTag key:"acquia:owner", value:"platform_classic">]
[2023-10-17 14:08:36] Waiting for: A record to be added with provider(s): route53
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
verify_host_key: false is deprecated, use :never
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
verify_host_key: false is deprecated, use :never
[2023-10-17 14:16:18] Rebooting instance as required by some packages.
[2023-10-17 14:16:20] Rebooting web-472.
[2023-10-17 14:16:24] Waiting for reboot...
[2023-10-17 14:16:30] Waiting for reboot...
[2023-10-17 14:16:35] Waiting for reboot...
[2023-10-17 14:16:40] Waiting for reboot...
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
[2023-10-17 14:16:50] SSH connection to ec2-34-239-155-190.compute-1.amazonaws.com failed: 'Net::SSH::ConnectionTimeout'. Retrying (1 / 6).
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
[2023-10-17 14:17:01] SSH connection to ec2-34-239-155-190.compute-1.amazonaws.com failed: 'Net::SSH::ConnectionTimeout'. Retrying (2 / 6).
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
[2023-10-17 14:17:12] SSH connection to ec2-34-239-155-190.compute-1.amazonaws.com failed: 'Net::SSH::ConnectionTimeout'. Retrying (3 / 6).
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
verify_host_key: false is deprecated, use :never
[2023-10-17 14:17:20] Reboot complete.
[2023-10-17 14:17:20] Turning on monitoring.
:paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.
verify_host_key: false is deprecated, use :never
[2023-10-17 14:18:24] Waiting for mntfs volume vol-0bfe75890e8dbf3f3 to be available.
[2023-10-17 14:18:24] Waiting for: {:status=>[:available]}
[2023-10-17 14:18:26] Attaching volume vol-0bfe75890e8dbf3f3 to web-472:/dev/xvdb.
[2023-10-17 14:18:26] Waiting for: {:status=>[:attaching, :attached]}
[2023-10-17 14:18:28] Waiting for mntfs volume vol-0bfe75890e8dbf3f3 to be in-use.
[2023-10-17 14:18:28] Waiting for: {:status=>[:in_use]}
[2023-10-17 14:18:28] Waiting for mntfs volume vol-0bfe75890e8dbf3f3 attachment status to be attached.
[2023-10-17 14:18:28] Waiting for: {:status=>[:attached]}
[2023-10-17 14:18:41] Waiting for web-472:/dev/xvdb to appear.
[2023-10-17 14:19:01] Successfully registered volumes with Hosting API.
[2023-10-17 14:19:24] Writing puppet conf to /etc/puppet/puppet.conf
[2023-10-17 14:19:55] Installing ah-puppet-manifest version 0.devel.master.2168fc1
[2023-10-17 14:20:12] Successfully installed ah-puppet-manifest version 0.devel.master.2168fc1
[2023-10-17 14:20:12] Executing /opt/ah-puppet-manifest/ah-puppet-run-apply "--detailed-exitcodes  --logdest=syslog --logdest=console"
[2023-10-17 14:28:15] Waiting for: web-472.ama-test.srvs.ahdev.co to resolve to 34.239.155.190
[2023-10-17 14:28:20] Launch took 1257 seconds
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ 
```
2. Created a site
```
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ ./fields-provision.php --create-site pc17326test2 --vcs svn-1 --bals bal-2 --webs web-467 --db fsdb-454 --stage dev
pc17326test2
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ 

[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ bundle exec ah-site edit pc17326test2 -s vcs_path=master
pc17326test2
  set vcs_path=master
Updated 1 sites.
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ 

[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ bundle exec ah-site install pc17326test2 https://ftp.drupal.org/files/projects/drupal-10.1.1.tar.gz
[2023-10-18 09:42:05] Task 1156025 is in state: received
[2023-10-18 09:42:12] State change received -> started.
[2023-10-18 09:43:44] State change started -> done.
[2023-10-18 09:43:44] Task 1156025 completed successfully.
[cloudservicesdev|hosting-dev:ama-test] ~/aquia/omesh-dhanushka/fields$ 
```
3. Install the package
```
[04:19:18] root@web-472.ama-test:/home/ahlauncher# apt list --installed | grep ah-web-server

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

ah-web-server/xenial,now 2.7.25 amd64 [installed]
[04:19:24] root@web-472.ama-test:/home/ahlauncher# 

[04:19:28] root@web-472.ama-test:/home/ahlauncher# apt update

[04:19:57] root@web-472.ama-test:/home/ahlauncher# apt install ah-web-server=2.7.27-PC17326-1-manual-tag-3
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  distro-info libyaml-dev linux-aws-tools-4.4.0-1128 linux-tools-4.4.0-1128-aws
Use 'sudo apt autoremove' to remove them.
The following packages will be upgraded:
  ah-web-server
1 upgraded, 0 newly installed, 0 to remove and 7 not upgraded.
Need to get 28.3 MB of archives.
After this operation, 8,495 kB of additional disk space will be used.
Get:1 s3://cloud-cds-apt-prod-apt-repo.s3.amazonaws.com xenial/main amd64 ah-web-server amd64 2.7.27-PC17326-1-manual-tag-3 [28.3 MB]
(Reading database ... 239841 files and directories currently installed.)
Preparing to unpack .../ah-web-server_2.7.27-PC17326-1-manual-tag-3_amd64.deb ...
Acquiring fields-config-web lock... done.
Unpacking ah-web-server (2.7.27-PC17326-1-manual-tag-3) over (2.7.25) ...
Processing triggers for systemd (229-4ubuntu21.31+esm1-acquia4~ubuntu16.04.1) ...
Processing triggers for ureadahead (0.100.0-19.1) ...
Setting up ah-web-server (2.7.27-PC17326-1-manual-tag-3) ...
ln: failed to create symbolic link '/usr/local/drush7/commands/commands': File exists
Ensure ah-dpld is started...
 done.
[04:20:32] root@web-472.ama-test:/home/ahlauncher# 
```
4. Run `fields-config-web`
```
[04:20:33] root@web-472.ama-test:/home/ahlauncher# fields-config-web.php --only-site pc17326test2
fields-config-web[23850]: task na: starting at 1697602866 (PID: 23850)
fields-config-web[23850]: Re-run ah-config-log
fields-config-web[23850]: task na: took 2, delay na, status 0
[04:21:08] root@web-472.ama-test:/home/ahlauncher# 
```
5. Verify the package is installed
```
[04:21:10] root@web-472.ama-test:/home/ahlauncher# apt list --installed | grep ah-web-server

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

ah-web-server/xenial,now 2.7.27-PC17326-1-manual-tag-3 amd64 [installed]
[04:21:22] root@web-472.ama-test:/home/ahlauncher# 
```
