### PR TITLE
Updated Fixture lock file for ruby 3.1.2

### DIFF
--- a/features/fixtures/basic-app/Gemfile.lock
+++ b/features/fixtures/basic-app/Gemfile.lock
@@ -15,28 +15,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    arr-pm (0.0.11)
-      cabin (> 0)
-    backports (3.21.0)
+    arr-pm (0.0.12)
+    backports (3.25.0)
+    bigdecimal (3.1.6)
     cabin (0.9.0)
     clamp (1.0.1)
-    dotenv (2.7.6)
-    fpm (1.14.1)
+    dotenv (3.1.0)
+    fpm (1.15.1)
       arr-pm (~> 0.0.11)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
       clamp (~> 1.0.0)
-      git (>= 1.3.0, < 2.0)
-      json (>= 1.7.7, < 3.0)
       pleaserun (~> 0.0.29)
       rexml
       stud
-    git (1.9.1)
-      rchardet (~> 1.8)
     insist (1.0.0)
-    json (2.6.1)
     mustache (0.99.8)
-    oj (3.13.9)
+    oj (3.16.3)
+      bigdecimal (>= 3.0)
     pleaserun (0.0.32)
       cabin (> 0)
       clamp
@@ -44,14 +40,14 @@ GEM
       insist
       mustache (= 0.99.8)
       stud
-    rake (13.0.6)
-    rchardet (1.8.0)
-    rexml (3.2.5)
-    sequel (5.51.0)
+    rake (13.1.0)
+    rexml (3.2.6)
+    sequel (5.78.0)
+      bigdecimal
     stud (0.0.23)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   basic!
@@ -59,4 +55,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.2.32
+   2.3.15


### PR DESCRIPTION
**Motivation**
The fixture app contains some old lock references to packages with CVEs. The lock file was missed updating during the ruby 3 upgrade.
